### PR TITLE
Use homebrew::tap instead of plain exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,9 @@
 class brewcask {
   require homebrew
 
-  exec { 'tap-homebrew-cask':
-    command => 'brew tap phinze/homebrew-cask',
-    creates => "${homebrew::config::installdir}/Library/Taps/phinze-cask"
-  }
+  homebrew::tap { 'phinze/homebrew-cask': }
 
   package { 'brew-cask':
-    require => Exec['tap-homebrew-cask']
+    require => Homebrew::Tap['phinze/homebrew-cask']
   }
 }


### PR DESCRIPTION
While setupping boxen for my desktop machine, `Exec[tap-homebrew-cask`] failed for me, because it wasn't able to find `brew` anywhere in the path.

Most of the times, you should explicitly specify the `path` option, because people may override the default with `Exec { path => ['...'] }`.

I worked around that, not by trying to guess the path in which `brew` will live, but by using the `homebrew::tap` resource, which takes care of it all.
