### PR TITLE
Change tapped repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,9 @@
 class brewcask {
   require homebrew
 
-  homebrew::tap { 'caskroom/homebrew-cask': }
+  homebrew::tap { 'caskroom/cask': }
 
   package { 'brew-cask':
-    require => Homebrew::Tap['caskroom/homebrew-cask']
+    require => Homebrew::Tap['caskroom/cask']
   }
 }


### PR DESCRIPTION
`homebrew-` prefix is not needed. Current version complains even cask has already tapped.

```
boxen --noop
```

=>

```
Notice: /Stage[main]/Brewcask/Homebrew::Tap[caskroom/homebrew-cask]/Homebrew_tap[caskroom/homebrew-cask]/ensure: current_value absent, should be present (noop)
Notice: Homebrew::Tap[caskroom/homebrew-cask]: Would have triggered 'refresh' from 1 events
```
