### PR TITLE
Fix for non-Boxen installs, non-root Puppet runs

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:package).provide :brewcask,
   end
 
   def command_opts
-    @command_opts ||= {
+    opts = {
       :combine              => true,
       :custom_environment   => {
         "HOME"              => "/Users/#{default_user}",
@@ -92,7 +92,9 @@ Puppet::Type.type(:package).provide :brewcask,
         "HOMEBREW_NO_EMOJI" => "Yes",
       },
       :failonfail           => true,
-      :uid                  => default_user
     }
+    # Only try to run as another user if Puppet is run as root.
+    opts[:uid] = default_user if Process.uid == 0
+    opts
   end
 end


### PR DESCRIPTION
This PR will make the provider work when not run as root, and will also make it work with non-Boxen installs of Homebrew. I'm sure the manifests still don't work without them, but my use case is to use this with a machine that has already been bootstrapped with Homebrew and brew-cask.
