### PR TITLE
Missing homebrew provider added

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,8 @@ class brewcask {
   }
 
   package { 'brew-cask':
-    require => Homebrew::Tap['caskroom/cask']
+    require  => Homebrew::Tap['caskroom/cask'],
+    provider => homebrew
   }
 
   Package['brew-cask'] -> Package <| provider == brewcask |>


### PR DESCRIPTION
The module relies on user having default package provider set to `homebrew` which may not be true necessarily.

If there's no default provider, installation of some packages (of certain types) end up in error (I'll add more details about the error later today).
