### PR TITLE
Puppet-Lint Warning fixed - Code linted

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@ class brewcask {
 
   # caskroom is hardcoded to '/opt/homebrew-cask/Caskroom'
   # https://github.com/caskroom/homebrew-cask/blob/master/lib/cask/locations.rb#L11
-  $cask_home = "/opt/homebrew-cask"
+  $cask_home = '/opt/homebrew-cask'
   $cask_room = "${cask_home}/Caskroom"
 
   homebrew::tap { 'caskroom/cask': }


### PR DESCRIPTION
Following warning is fixed in this PR:

```
manifests/init.pp - WARNING: double quoted string containing no variables on line 6
```
