### PR TITLE
Support customized homebrew_root

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -16,11 +16,7 @@ Puppet::Type.type(:package).provide :brewcask,
   end
 
   def self.home
-    if boxen_home = Facter.value(:boxen_home)
-      "#{boxen_home}/homebrew"
-    else
-      "/usr/local"
-    end
+    Facter.value(:homebrew_root)
   end
 
   def self.caskroom


### PR DESCRIPTION
Users can set homebrew's root after this [PR](https://github.com/boxen/puppet-homebrew/pull/70), so we should always refer to `facter[:homebrew_root]`. If not, `brew` binary cannot be found.