### PR TITLE
Support for caskroom/fonts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class brewcask {
   $cask_room = "${cask_home}/Caskroom"
 
   homebrew::tap { 'caskroom/cask': }
+  homebrew::tap { 'caskroom/fonts': }
 
   file { $cask_home:
     ensure => directory
@@ -26,7 +27,7 @@ class brewcask {
   }
 
   package { 'brew-cask':
-    require  => Homebrew::Tap['caskroom/cask'],
+    require  => Homebrew::Tap['caskroom/cask','caskroom/fonts'],
     provider => homebrew
   }
 


### PR DESCRIPTION
## Ideal

Allow [cask font install](https://github.com/caskroom/homebrew-fonts) analogous to app installs.

```yaml
# hiera/users/toolbear.yaml

boxen::personal::osx_apps:
  - 1password
  ...

boxen::personal::fonts
  - source-code-pro
```

* Tap `caskroom/fonts`
*  A separate `brewfont` provider
* implicit `font-` prefix so you say `source-code-pro` not `font-source-code-pro`

## Hacked together so far

With boxen/puppet-boxen#124

```yaml
boxen::personal::fonts:
  - source-code-pro
```

Behind the scenes it's still just a `Package[font-source-code-pro]` with `brewcask` provider.

## TODO

* [ ] agree on usage; backfill tests
* [ ] `brewfont` provider
* [x] add `boxen::personal::fonts` support to `personal.pp` (boxen/puppet-boxen#124)
* [ ] separation from `brewcask` provider so you can't install fonts with brewcask nor apps with brewfont