### PR TITLE
Updates brewcask_root location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package { 'firefox': provider => 'brewcask' }
 ## Custom facts
 
  - `brewcask_root` (only overridable from `$BOXEN_REPO_DIR/facts.d/`)
-   - default is `/opt/homebrew-cask`
+   - default is `/usr/local`
 
 ## Required Puppet Modules
 

--- a/lib/facter/brewcask_root.rb
+++ b/lib/facter/brewcask_root.rb
@@ -4,5 +4,5 @@ Facter.add(:brewcask_root) do
   # Explicit, low weight makes this easily overridable
   has_weight 1
 
-  setcode { '/opt/homebrew-cask' }
+  setcode { '/usr/local' }
 end


### PR DESCRIPTION
Inline with #47 and https://github.com/caskroom/homebrew-cask/pull/21901 the default brewcask_root location should be changed so boxen doesn't throw warnings.