### PR TITLE
Remove Homebrew management from Brewcask

### DIFF
--- a/lib/facter/brewcask_root.rb
+++ b/lib/facter/brewcask_root.rb
@@ -1,8 +1,0 @@
-Facter.add(:brewcask_root) do
-  confine :operatingsystem => 'Darwin'
-
-  # Explicit, low weight makes this easily overridable
-  has_weight 1
-
-  setcode { '/usr/local' }
-end

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -1,8 +1,7 @@
 require "puppet/provider/package"
 require "puppet/util/execution"
 
-Puppet::Type.type(:package).provide :brewcask,
-  :parent => Puppet::Provider::Package do
+Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Package do
   include Puppet::Util::Execution
 
   confine :operatingsystem => :darwin

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -96,7 +96,6 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
       :custom_environment    => {
         "HOME"               => "/Users/#{default_user}",
         "PATH"               => "#{self.class.home}/bin:/usr/bin:/usr/sbin:/bin:/sbin",
-        "HOMEBREW_CASK_OPTS" => "--caskroom=#{self.class.caskroom}",
         "HOMEBREW_NO_EMOJI"  => "Yes",
       },
       :failonfail            => true,

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -20,12 +20,24 @@ Puppet::Type.type(:package).provide :brewcask,
   end
 
   def self.caskroom
-    "#{Facter[:brewcask_root].value}/Caskroom"
+    if legacy_caskroom.exist?
+      legacy_caskroom
+    else
+      new_caskroom
+    end
   end
 
   def self.current(name)
     caskdir = Pathname.new "#{caskroom}/#{name}"
     caskdir.directory? && caskdir.children.size >= 1 && caskdir.children.sort.last.to_s
+  end
+
+  def self.legacy_caskroom
+    @legacy_caskroom ||= Pathname.new('/opt/homebrew-cask/Caskroom')
+  end
+
+  def self.new_caskroom
+    @new_caskroom ||= Pathname.new("#{self.class.home}/Caskroom")
   end
 
   def query

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -20,9 +20,9 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
 
   def self.caskroom
     if legacy_caskroom.exist?
-      legacy_caskroom
+      legacy_caskroom.to_s
     else
-      new_caskroom
+      new_caskroom.to_s
     end
   end
 

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def self.new_caskroom
-    @new_caskroom ||= Pathname.new("#{self.class.home}/Caskroom")
+    @new_caskroom ||= Pathname.new("#{home}/Caskroom")
   end
 
   def query

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,8 @@
 class brewcask {
+  include boxen::config
   require homebrew
 
+  file { "${boxen::config::envdir}/10_brewcask.sh":
+    ensure => 'absent'
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,29 +1,5 @@
-# Public: Install and configure brewcask for use with Boxen.
-#
-# Examples
-#
-#   include brewcask
-
 class brewcask {
   require homebrew
 
-  $cask_home = $::brewcask_root
-  $cask_room = "${cask_home}/Caskroom"
-
-  homebrew::tap { 'caskroom/cask': }
-
-  file { $cask_home:
-    ensure => directory
-  }
-
-  # This prevents typing root password the first time a cask is installed
-  file { $cask_room:
-    ensure  => directory,
-    require => File[$cask_home]
-  }
-
-  boxen::env_script { 'brewcask':
-    content  => template('brewcask/env.sh.erb'),
-    priority => highest,
   }
 }

--- a/spec/classes/brewcask_spec.rb
+++ b/spec/classes/brewcask_spec.rb
@@ -2,18 +2,4 @@ require 'spec_helper'
 
 describe 'brewcask' do
   let(:facts) { default_test_facts }
-
-  it do
-    should contain_class('homebrew')
-    should contain_homebrew__tap('caskroom/cask')
-  end
-
-  it do
-    should contain_file('/test/custom/homebrew-cask').with_ensure('directory')
-    should contain_file('/test/custom/homebrew-cask/Caskroom').with_ensure('directory')
-  end
-
-  it do
-    should contain_boxen__env_script('brewcask').with_ensure('present')
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,5 @@ def default_test_facts
     :boxen_home    => "/test/boxen",
     :boxen_srcdir  => "/test/boxen/src",
     :boxen_user    => "testuser",
-    :brewcask_root => "/test/custom/homebrew-cask"
   }
 end

--- a/templates/env.sh.erb
+++ b/templates/env.sh.erb
@@ -1,1 +1,0 @@
-export HOMEBREW_CASK_OPTS="--caskroom=<%= @cask_room %>"


### PR DESCRIPTION
Since Homebrew + Brewcask merged, these two modules have been attempting to
share the load of managing their own interactions despite being one upstream.
This has caused a bit of pain because they were trying to manage the upstream
Homebrew changes independently which is :thumbsdown: as they are intended to be
done in one place.

To fix this, I've ripped out any resource management from this repository
(since it is already handled by `puppet-homebrew`) and the only things I am
leaving here are the Puppet providers because Puppet doesn't like when you try
and define providers for two modules in one.

I did initially try to consolidate this boxen/puppet-homebrew#103 however as I
mentioned above, Puppet's internals have a very specific pattern they expect
you to follow and this violated it causing namespace and load issues.