### PR TITLE
Use `boxen-install` for installing Casks

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -45,20 +45,19 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def install
-    run "install", resource[:name], *install_options
+    if install_options.any?
+      execute ["brew", "install", "Caskroom/cask/#{resource[:name]}", *install_options].flatten, command_opts
+    else
+      execute ["brew", "boxen-install", "Caskroom/cask/#{resource[:name]}"], command_opts
+    end
   end
 
   def uninstall
-    run "uninstall", resource[:name]
+    execute "brew", "uninstall", "--force", resource[:name]
   end
 
   def install_options
     Array(resource[:install_options]).flatten.compact
-  end
-
-  def run(*cmds)
-    brew_cmd = ["brew", "cask"] + cmds
-    execute brew_cmd, command_opts
   end
 
   private


### PR DESCRIPTION
Whilst trying to install [shortcat](https://shortcatapp.com) via cask, I got the following
error:

```
==> sudo: no tty present and no askpass program specified
Error: /Stage[main]/Boxen::Personal/Package[shortcat]/ensure: change from absent to present failed: Execution of 'brew cask install shortcat --appdir=/Applications --binarydir=/opt/boxen/homebrew/bin' returned 1: Warning: Option --binarydir is obsolete!
Homebrew-Cask now uses the same location as your Homebrew installation for executable links.
==> Downloading https://files.shortcatapp.com/v0.7.7/Shortcat.zip
  Already downloaded:
  /Users/Jacob/Library/Caches/Homebrew/Cask/shortcat--0.7.7.zip
==> Verifying checksum for Cask shortcat
==> Moving App 'Shortcat.app' to '/Applications/Shortcat.app'.
==> Enabling accessibility access
Error: Command failed to execute!
```

This is because the application requires the user to input their
password however it times out waiting (since it's under Boxen). To
resolve this we can use `boxen-install` which among other things,
maintains your priviledged session and plugs in your sudo password when
needed.

The approach taken here is similar to [`boxen/puppet-homebrew`](https://github.com/boxen/puppet-homebrew/blob/master/lib/puppet/provider/package/homebrew.rb#L60-L86).