### PR TITLE
Use `brew cask` uninstall instead of just `brew`

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def uninstall
-    execute "brew", "uninstall", "--force", resource[:name]
+    execute ["brew", "cask", "uninstall", "--force", resource[:name]]
   end
 
   def install_options


### PR DESCRIPTION
In #51 we updated the command for installing and uninstalling to be more
consistent with `boxen/puppet-homebrew` however @zhenkyle noted in #52
that the uninstall does not work as intended.

After multiple attempts at this, we've decided to just move the
uninstall back to the normal `brew cask uninstall` instead.

Fixes #52