### PR TITLE
Add brew-boxen-cask-install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 ---
-os:
-  - osx
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+os:
+  - osx
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,16 +4,16 @@ GEM
     CFPropertyList (2.3.6)
     addressable (2.3.8)
     ansi (1.5.0)
-    boxen (2.9.0)
+    boxen (3.1.3)
       ansi (~> 1.4)
       hiera (~> 1.0)
       highline (~> 1.6.0)
       json_pure (>= 1.7.7, < 2.0)
-      librarian-puppet (~> 1.0.0)
+      librarian-puppet (~> 2.2)
       octokit (~> 2.7, >= 2.7.1)
       puppet (~> 3.7)
-    cardboard (2.1.0)
-      boxen (~> 2.1)
+    cardboard (2.1.1)
+      boxen (~> 3.1)
       puppet-lint (~> 0.3)
       puppetlabs_spec_helper (~> 0.4)
       rspec-puppet (~> 1.0)
@@ -23,18 +23,29 @@ GEM
       CFPropertyList (~> 2.2)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.2)
+    gettext (3.2.6)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.30)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
     hiera (1.3.4)
       json_pure
     highline (1.6.21)
-    json (2.1.0)
     json_pure (1.8.6)
-    librarian (0.1.2)
-      highline
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.4)
       thor (~> 0.15)
-    librarian-puppet (1.0.9)
-      json
-      librarian (>= 0.1.2)
+    locale (2.1.2)
     metaclass (0.0.4)
+    minitar (0.6.1)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     multipart-post (2.0.0)
@@ -47,6 +58,12 @@ GEM
     puppet-lint (0.3.2)
     puppet-syntax (2.4.1)
       rake
+    puppet_forge (2.2.9)
+      faraday (>= 0.9.0, < 0.14.0)
+      faraday_middleware (>= 0.9.0, < 0.13.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 1.0)
     puppetlabs_spec_helper (0.10.3)
       mocha
       puppet-lint
@@ -69,9 +86,13 @@ GEM
     rspec-puppet (1.0.1)
       rspec
     rspec-support (3.7.1)
+    rsync (1.0.9)
     sawyer (0.5.5)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    semantic_puppet (1.0.1)
+      gettext-setup (>= 0.3)
+    text (1.3.1)
     thor (0.20.0)
 
 PLATFORMS
@@ -82,4 +103,4 @@ DEPENDENCIES
   cardboard (~> 2.1)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.6)
     addressable (2.3.8)
     ansi (1.5.0)
     boxen (2.9.0)
@@ -18,6 +19,8 @@ GEM
       rspec-puppet (~> 1.0)
     diff-lcs (1.3)
     facter (2.5.1)
+    facter (2.5.1-universal-darwin)
+      CFPropertyList (~> 2.2)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     hiera (1.3.4)
@@ -50,12 +53,12 @@ GEM
       puppet-syntax
       rake
       rspec-puppet
-    rake (12.2.1)
+    rake (12.3.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -65,7 +68,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-puppet (1.0.1)
       rspec
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     sawyer (0.5.5)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -73,6 +76,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-16
 
 DEPENDENCIES
   cardboard (~> 2.1)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ package { 'firefox': provider => 'brewcask' }
 
 ## Required Puppet Modules
 
- - `homebrew`, >= 1.10.0
+ - `homebrew` >= 1.10.0
 
 ## Work in progress
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ package { 'firefox': provider => 'brewcask' }
 
 ## Required Puppet Modules
 
- - `homebrew` >= 1.10.0
+* `homebrew`, >= 1.10
 
 ## Work in progress
 

--- a/files/brew-boxen-cask-install.rb
+++ b/files/brew-boxen-cask-install.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift("#{HOMEBREW_LIBRARY_PATH}/cask/lib")
+require "hbc"
+
+Hbc::CLI::Install.new(ARGV).run

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -1,5 +1,5 @@
-require "puppet/provider/package"
-require "puppet/util/execution"
+require 'puppet/provider/package'
+require 'puppet/util/execution'
 
 Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Package do
   include Puppet::Util::Execution
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def self.current(name)
-    caskdir = Pathname.new "#{caskroom}/#{name}"
+    caskdir = Pathname.new '#{caskroom}/#{name}'
     caskdir.directory? && caskdir.children.size >= 1 && caskdir.children.sort.last.to_s
   end
 
@@ -36,7 +36,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def self.new_caskroom
-    @new_caskroom ||= Pathname.new("#{home}/Caskroom")
+    @new_caskroom ||= Pathname.new('#{home}/Caskroom')
   end
 
   def query
@@ -45,15 +45,20 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def install
+    install_cmd = ['brew']
     if install_options.any?
-      execute ["brew", "install", "Caskroom/cask/#{resource[:name]}", *install_options].flatten, command_opts
+      install_cmd << 'cask install'
     else
-      execute ["brew", "boxen-install", "Caskroom/cask/#{resource[:name]}"], command_opts
+      install_cmd << 'boxen-cask-install'
     end
+    install_cmd << install_options if install_options.any?
+    install_cmd << resource[:name]
+
+    execute install_cmd.flatten, command_opts
   end
 
   def uninstall
-    execute ["brew", "cask", "uninstall", "--force", resource[:name]]
+    execute ['brew', 'cask', 'uninstall', '--force', resource[:name]]
   end
 
   def install_options
@@ -86,18 +91,18 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def default_user
-    Facter.value(:boxen_user) || Facter.value(:id) || "root"
+    Facter.value(:boxen_user) || Facter.value(:id) || 'root'
   end
 
   def command_opts
     opts = {
-      :combine               => true,
-      :custom_environment    => {
-        "HOME"               => "/Users/#{default_user}",
-        "PATH"               => "#{self.class.home}/bin:/usr/bin:/usr/sbin:/bin:/sbin",
-        "HOMEBREW_NO_EMOJI"  => "Yes",
+      :combine              => true,
+      :custom_environment   => {
+        'HOME'              => "/Users/#{default_user}",
+        'PATH'              => "#{self.class.home}/bin:/usr/bin:/usr/sbin:/bin:/sbin",
+        'HOMEBREW_NO_EMOJI' => 'Yes',
       },
-      :failonfail            => true,
+      :failonfail           => true,
     }
     # Only try to run as another user if Puppet is run as root.
     opts[:uid] = default_user if Process.uid == 0

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def self.current(name)
-    caskdir = Pathname.new '#{caskroom}/#{name}'
+    caskdir = Pathname.new "#{caskroom}/#{name}"
     caskdir.directory? && caskdir.children.size >= 1 && caskdir.children.sort.last.to_s
   end
 
@@ -36,7 +36,7 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
   end
 
   def self.new_caskroom
-    @new_caskroom ||= Pathname.new('#{home}/Caskroom')
+    @new_caskroom ||= Pathname.new("#{home}/Caskroom")
   end
 
   def query
@@ -48,10 +48,10 @@ Puppet::Type.type(:package).provide :brewcask, :parent => Puppet::Provider::Pack
     install_cmd = ['brew']
     if install_options.any?
       install_cmd << 'cask install'
+      install_cmd << install_options
     else
       install_cmd << 'boxen-cask-install'
     end
-    install_cmd << install_options if install_options.any?
     install_cmd << resource[:name]
 
     execute install_cmd.flatten, command_opts

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,11 @@ class brewcask {
   require homebrew
 
   file { "${boxen::config::envdir}/10_brewcask.sh":
-    ensure => 'absent'
+    ensure => 'absent',
+  }
+
+  file { "${homebrew::config::brewsdir}/cmd/brew-boxen-cask-install.rb":
+    source => 'puppet:///modules/brewcask/brew-boxen-cask-install.rb',
+    mode   => '0755',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,8 @@
+# Public: Install and configure homebrew cask for use with Boxen.
+#
+# Examples
+#
+#   include brewcask
 class brewcask {
   include boxen::config
   require homebrew

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,4 +15,6 @@ class brewcask {
     source => 'puppet:///modules/brewcask/brew-boxen-cask-install.rb',
     mode   => '0755',
   }
+
+  homebrew::tap { 'caskroom/cask': }
 }

--- a/spec/classes/brewcask_spec.rb
+++ b/spec/classes/brewcask_spec.rb
@@ -2,4 +2,16 @@ require 'spec_helper'
 
 describe 'brewcask' do
   let(:facts) { default_test_facts }
+
+  it do
+    should contain_class('boxen::config')
+    should contain_class('homebrew')
+
+    should contain_file('/test/boxen/env.d/10_brewcask.sh').
+      with_ensure('absent')
+
+    should contain_file('/test/boxen/homebrew/Library/Taps/boxen-brews/cmd/brew-boxen-cask-install.rb').
+      with_source('puppet:///modules/brewcask/brew-boxen-cask-install.rb').
+      with_mode('0755')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,16 @@
-require "rspec-puppet"
+require 'rspec-puppet'
 
-fixture_path = File.expand_path File.join(__FILE__, "..", "fixtures")
+fixture_path = File.expand_path File.join(__FILE__, '..', 'fixtures')
 
 RSpec.configure do |c|
-  c.manifest_dir = File.join(fixture_path, "manifests")
-  c.module_path  = File.join(fixture_path, "modules")
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.module_path  = File.join(fixture_path, 'modules')
 end
 
 def default_test_facts
   {
-    :boxen_home    => "/test/boxen",
-    :boxen_srcdir  => "/test/boxen/src",
-    :boxen_user    => "testuser",
+    :boxen_home   => '/test/boxen',
+    :boxen_srcdir => '/test/boxen/src',
+    :boxen_user   => 'testuser',
   }
 end

--- a/spec/unit/provider/package/brewcask_spec.rb
+++ b/spec/unit/provider/package/brewcask_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+provider = Puppet::Type.type(:package).provider(:brewcask)
+
+describe provider do
+  it 'should have an install method' do
+    is_expected.to respond_to(:install)
+  end
+
+  it 'should have a uninstall method' do
+    is_expected.to respond_to(:uninstall)
+  end
+
+  it 'should not have a latst method' do
+    is_expected.not_to respond_to(:latest)
+  end
+
+  it 'should not have a update method' do
+    is_expected.not_to respond_to(:update)
+  end
+
+  describe 'when installing' do
+    context 'installing cask without install options' do
+      before do
+        @resource = Puppet::Type.type(:package).new(
+                                                    :name     => 'cask',
+                                                    :ensure   => :present,
+                                                    :provider => :brewcask,
+                                                   )
+        @provider = provider.new(@resource)
+      end
+
+      it 'should return install command' do
+        expect{ @provider.install }.to raise_error(Puppet::ExecutionFailure,
+                                                    /brew boxen-cask-install cask/)
+      end
+
+      it 'should return nil query' do
+        expect(@provider.query).to eq(nil)
+      end
+    end
+
+    context 'installing cask with install options' do
+      before do
+        @resource = Puppet::Type.type(:package).new(
+                                                    :name     => 'cask',
+                                                    :ensure   => :present,
+                                                    :provider => :brewcask,
+                                                    :install_options => '--foo',
+                                                   )
+        @provider = provider.new(@resource)
+      end
+
+      it 'should return install command with install options' do
+        expect { @provider.install }.to raise_error(Puppet::ExecutionFailure,
+                                                    /brew cask install --foo cask/)
+      end
+    end
+  end
+
+  describe 'when uninstalling' do
+      before do
+        @resource = Puppet::Type.type(:package).new(
+                                                    :name     => 'cask',
+                                                    :ensure   => :present,
+                                                    :provider => :brewcask,
+                                                   )
+        @provider = provider.new(@resource)
+      end
+
+      it 'should return uninstall command' do
+        expect { @provider.uninstall }.to raise_error(Puppet::ExecutionFailure,
+                                                      /brew cask uninstall --force cask/)
+      end
+  end
+end

--- a/spec/unit/provider/package/brewcask_spec.rb
+++ b/spec/unit/provider/package/brewcask_spec.rb
@@ -47,7 +47,7 @@ describe provider do
                                                     :ensure   => :present,
                                                     :provider => :brewcask,
                                                     :install_options => '--foo',
-                                                   )
+                                                    )
         @provider = provider.new(@resource)
       end
 
@@ -64,7 +64,7 @@ describe provider do
                                                     :name     => 'mycask',
                                                     :ensure   => :present,
                                                     :provider => :brewcask,
-                                                   )
+                                                    )
         @provider = provider.new(@resource)
       end
 

--- a/spec/unit/provider/package/brewcask_spec.rb
+++ b/spec/unit/provider/package/brewcask_spec.rb
@@ -23,7 +23,7 @@ describe provider do
     context 'installing cask without install options' do
       before do
         @resource = Puppet::Type.type(:package).new(
-                                                    :name     => 'cask',
+                                                    :name     => 'mycask',
                                                     :ensure   => :present,
                                                     :provider => :brewcask,
                                                    )
@@ -32,7 +32,7 @@ describe provider do
 
       it 'should return install command' do
         expect{ @provider.install }.to raise_error(Puppet::ExecutionFailure,
-                                                    /brew boxen-cask-install cask/)
+                                                    /brew boxen-cask-install mycask/)
       end
 
       it 'should return nil query' do
@@ -43,7 +43,7 @@ describe provider do
     context 'installing cask with install options' do
       before do
         @resource = Puppet::Type.type(:package).new(
-                                                    :name     => 'cask',
+                                                    :name     => 'mycask',
                                                     :ensure   => :present,
                                                     :provider => :brewcask,
                                                     :install_options => '--foo',
@@ -53,7 +53,7 @@ describe provider do
 
       it 'should return install command with install options' do
         expect { @provider.install }.to raise_error(Puppet::ExecutionFailure,
-                                                    /brew cask install --foo cask/)
+                                                    /brew cask install --foo mycask/)
       end
     end
   end
@@ -61,7 +61,7 @@ describe provider do
   describe 'when uninstalling' do
       before do
         @resource = Puppet::Type.type(:package).new(
-                                                    :name     => 'cask',
+                                                    :name     => 'mycask',
                                                     :ensure   => :present,
                                                     :provider => :brewcask,
                                                    )
@@ -70,7 +70,7 @@ describe provider do
 
       it 'should return uninstall command' do
         expect { @provider.uninstall }.to raise_error(Puppet::ExecutionFailure,
-                                                      /brew cask uninstall --force cask/)
+                                                      /brew cask uninstall --force mycask/)
       end
   end
 end


### PR DESCRIPTION
Hello, brew install Caskroom/versions/google-chrome-canary is not working.
And my custom cask is not installing via puppet-brewcask module.
So I add brew custom install command `brew boxen-cask-install <cask>`.

Thanks,
